### PR TITLE
makefile added

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
 installdir = $(libdir)/enigma2/python/Plugins/Extensions/SeriesPlugin
 SUBDIRS = Identifiers Logos Images Skins
 install_PYTHON = *.py
-install_DATA = *.xml maintainer.info LICENSE plugin.png 
+install_DATA = maintainer.info LICENSE plugin.png 

--- a/src/Skins/Makefile.am
+++ b/src/Skins/Makefile.am
@@ -1,0 +1,2 @@
+installdir = $(libdir)/enigma2/python/Plugins/Extensions/SeriesPlugin/Skins
+install_DATA = *.xml


### PR DESCRIPTION
The Skins folder does not contain a makefile.am which is needed to create an IPK package using bitbake and autotools.
